### PR TITLE
Allow access to the Django Admin without a profile

### DIFF
--- a/helpdesk/accounts/middleware.py
+++ b/helpdesk/accounts/middleware.py
@@ -30,5 +30,9 @@ class ProfileMiddleware:
 
     def _request_requires_profile(self, request: HttpRequest) -> bool:
         path_info = resolve(request.path_info)
+
+        if path_info.app_name == "admin":
+            return False
+
         path = (path_info.app_name or None, path_info.url_name)
         return path not in self.EXCLUDED_PATHS


### PR DESCRIPTION
This allows users to configure the initial queues through the UI, rather than forcing that to happen from a shell.

Fixes https://github.com/trickeydan/helpdesk-system/issues/10