### PR TITLE
Require that users provide a given name

### DIFF
--- a/helpdesk/accounts/views.py
+++ b/helpdesk/accounts/views.py
@@ -18,12 +18,12 @@ class ProfileUpdateView(LoginRequiredMixin, UpdateView):
     def get_object(self, queryset: models.QuerySet[User] | None = None) -> User:
         assert self.request.user.is_authenticated
         return self.request.user
-    
+
     def get_form(self, form_class: type[BaseModelForm] | None = None) -> BaseModelForm:
         form = super().get_form(form_class)
-        # Modify generated form to require name fields.
-        form.fields["first_name"].required = True
-        form.fields["last_name"].required = True
+        # Modify generated form to require a name.
+        form.fields['first_name'].required = True
+        form.fields['first_name'].label = "Given name"
         return form
 
     def get_success_url(self) -> str:


### PR DESCRIPTION
We need at least one name so we know who it is, however for many people a single name will suffice. Treat this as their given name rather than enforcing it being a first name to provide them a bit more freedom.

If we were going full https://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/ I'd drop the 'last_name' field and just have the one field, but this is probably sufficient.