### PR TITLE
Fix static file serving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -274,3 +274,5 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+helpdesk/collected-static

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ format-check:
 	find $(PYMODULE) -name "*.html" | xargs $(CMD) djhtml --check
 	$(CMD) ruff format --check $(PYMODULE)
 
-lint: 
+lint:
 	$(CMD) ruff check $(PYMODULE)
 
-lint-fix: 
+lint-fix:
 	$(CMD) ruff check --fix $(PYMODULE)
 
 check:
@@ -28,10 +28,11 @@ check:
 dev:
 	$(MANAGEPY) runserver
 
-type: 
+type:
 	cd helpdesk && mypy $(APPS)
 
 test: | $(PYMODULE)
+	$(MANAGEPY) collectstatic --noinput
 	cd helpdesk && DJANGO_SETTINGS_MODULE=helpdesk.settings pytest --cov=. $(APPS) $(PYMODULE)
 
 test-cov:

--- a/helpdesk/helpdesk/settings.py
+++ b/helpdesk/helpdesk/settings.py
@@ -169,6 +169,8 @@ STATICFILES_DIRS = [
 ]
 STATIC_URL = f"/{BASE_PATH}static/"
 
+STATIC_ROOT = BASE_DIR / "collected-static"
+
 # Authentication URLs
 LOGIN_URL = f"/{BASE_PATH}auth/login/"
 LOGOUT_REDIRECT_URL = LOGIN_URL


### PR DESCRIPTION
It seems in a previous refactor, `STATIC_ROOT` was unset. This causes issues when running `collectstatic`, but works fine in development.

This is now also added to CI